### PR TITLE
feat: Allow enabling DynamoDB PITR

### DIFF
--- a/modules/control_plane/fleet/main.tf
+++ b/modules/control_plane/fleet/main.tf
@@ -180,6 +180,10 @@ resource "aws_dynamodb_table" "claims" {
     attribute_name = "ttl"
   }
 
+  point_in_time_recovery {
+    enabled = var.enable_dynamodb_pitr
+  }
+
   tags = merge(
     var.tags,
     {

--- a/modules/control_plane/fleet/variables.tf
+++ b/modules/control_plane/fleet/variables.tf
@@ -122,6 +122,12 @@ variable "compute" {
   })
 }
 
+variable "enable_dynamodb_pitr" {
+  description = "Enable point-in-time recovery (PITR) on the Fleet control plane DynamoDB tables"
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Tags applied to Fleet resources"
   type        = map(string)

--- a/modules/control_plane/flex/dynamodb.tf
+++ b/modules/control_plane/flex/dynamodb.tf
@@ -20,6 +20,10 @@ resource "aws_dynamodb_table" "locks" {
     attribute_name = "expiresAt"
   }
 
+  point_in_time_recovery {
+    enabled = var.enable_dynamodb_pitr
+  }
+
   tags = merge(
     local.common_tags,
     {
@@ -126,6 +130,10 @@ resource "aws_dynamodb_table" "workflow_jobs" {
   ttl {
     enabled        = true
     attribute_name = "ttl"
+  }
+
+  point_in_time_recovery {
+    enabled = var.enable_dynamodb_pitr
   }
 
   tags = merge(

--- a/modules/control_plane/flex/variables.tf
+++ b/modules/control_plane/flex/variables.tf
@@ -188,6 +188,12 @@ variable "alerts" {
   }
 }
 
+variable "enable_dynamodb_pitr" {
+  description = "Enable point-in-time recovery (PITR) on the control plane DynamoDB tables"
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Additional tags for all resources"
   type        = map(string)

--- a/modules/fleet/main.tf
+++ b/modules/fleet/main.tf
@@ -117,6 +117,8 @@ module "control_plane" {
   runtime       = local.fleet_runtime
   control_plane = local.fleet_control_plane
   tags          = local.common_tags
+
+  enable_dynamodb_pitr = var.enable_dynamodb_pitr
 }
 
 locals {

--- a/modules/fleet/variables.tf
+++ b/modules/fleet/variables.tf
@@ -193,6 +193,12 @@ variable "force_destroy_buckets" {
   default     = false
 }
 
+variable "enable_dynamodb_pitr" {
+  description = "Enable point-in-time recovery (PITR) on control plane DynamoDB tables. Disabled by default; enable for production to meet backup/recovery requirements (incurs additional DynamoDB storage cost)."
+  type        = bool
+  default     = false
+}
+
 variable "log_retention_days" {
   description = "CloudWatch Logs retention in days."
   type        = number

--- a/modules/flex/main.tf
+++ b/modules/flex/main.tf
@@ -223,6 +223,8 @@ module "control_plane" {
   alerts              = local.flex_alerts
   tags                = local.common_tags
 
+  enable_dynamodb_pitr = var.enable_dynamodb_pitr
+
   # Ensure NAT gateway is ready before the worker service starts
   depends_on = [
     time_sleep.wait_for_nat

--- a/modules/flex/variables.tf
+++ b/modules/flex/variables.tf
@@ -151,6 +151,12 @@ variable "force_destroy_buckets" {
   default     = false
 }
 
+variable "enable_dynamodb_pitr" {
+  description = "Enable point-in-time recovery (PITR) on control plane DynamoDB tables. Disabled by default; enable for production to meet backup/recovery requirements (incurs additional DynamoDB storage cost)."
+  type        = bool
+  default     = false
+}
+
 ###########################
 # Compute Configuration
 # Used by: compute module


### PR DESCRIPTION
We need to be able to enable Point in Time Recovery on all our DynamoDB tables to keep our compliance checker (Vanta) happy. 
This PR adds a `var.enable_dynamodb_pitr` variable to the modules, to expose this option.

