### PR TITLE
fix: lambda archive filename path sensitivity

### DIFF
--- a/modules/control_plane/alerts/main.tf
+++ b/modules/control_plane/alerts/main.tf
@@ -15,7 +15,7 @@ terraform {
 
 locals {
   slack_webhook_enabled  = trimspace(var.slack_webhook_url) != ""
-  lambda_artifact_prefix = "${path.root}/.terraform/runs-on-${substr(sha1(path.cwd), 0, 8)}-${var.stack_name}"
+  lambda_artifact_prefix = "${path.root}/.terraform/runs-on-${substr(sha1(var.stack_name), 0, 8)}-${var.stack_name}"
 }
 
 resource "aws_sns_topic" "alerts" {

--- a/modules/control_plane/fleet/job_diagnostics_resolver.tf
+++ b/modules/control_plane/fleet/job_diagnostics_resolver.tf
@@ -1,6 +1,6 @@
 data "archive_file" "job_diagnostics_resolver" {
   type        = "zip"
-  output_path = "${path.root}/.terraform/runs-on-${substr(sha1(path.cwd), 0, 8)}-${var.stack_name}-job-diagnostics-resolver.zip"
+  output_path = "${path.root}/.terraform/runs-on-${substr(sha1(var.stack_name), 0, 8)}-${var.stack_name}-job-diagnostics-resolver.zip"
 
   source {
     content  = file("${path.module}/../../../lambdas/job_diagnostics_resolver.js")

--- a/modules/control_plane/fleet/secrets.tf
+++ b/modules/control_plane/fleet/secrets.tf
@@ -1,6 +1,6 @@
 data "archive_file" "config_materializer" {
   type        = "zip"
-  output_path = "${path.root}/.terraform/runs-on-${substr(sha1(path.cwd), 0, 8)}-${var.stack_name}-fleet-config-materializer.zip"
+  output_path = "${path.root}/.terraform/runs-on-${substr(sha1(var.stack_name), 0, 8)}-${var.stack_name}-fleet-config-materializer.zip"
 
   source {
     content  = <<-PY

--- a/modules/control_plane/flex/main.tf
+++ b/modules/control_plane/flex/main.tf
@@ -22,7 +22,7 @@ locals {
   alerts                                = var.alerts
   common_tags                           = var.tags
   admin_routes_enabled                  = local.operations.enable_admin_routes
-  lambda_artifact_prefix                = "${path.root}/.terraform/runs-on-${substr(sha1(path.cwd), 0, 8)}-${var.stack_name}"
+  lambda_artifact_prefix                = "${path.root}/.terraform/runs-on-${substr(sha1(var.stack_name), 0, 8)}-${var.stack_name}"
   public_ingress_web_acl_arn_trimmed    = trimspace(local.operations.public_ingress_web_acl_arn)
   using_user_managed_public_ingress_waf = local.operations.enable_waf && local.public_ingress_web_acl_arn_trimmed != ""
   using_managed_public_ingress_waf      = local.operations.enable_waf && local.public_ingress_web_acl_arn_trimmed == "" && trimspace(local.github.enterprise_url) == ""

--- a/modules/flex/test/plan_test.go
+++ b/modules/flex/test/plan_test.go
@@ -71,6 +71,22 @@ func TestPlanSourceFleetConfigMaterializerWiring(t *testing.T) {
 	assert.Contains(t, mainTF, `deployment_method                      = "terraform"`)
 }
 
+func TestPlanSourceLambdaArtifactPathsDoNotDependOnWorkingDirectory(t *testing.T) {
+	t.Parallel()
+
+	files := map[string]string{
+		"control_plane/flex/main.tf":                      readTerraformSource(t, "modules", "control_plane", "flex", "main.tf"),
+		"control_plane/fleet/job_diagnostics_resolver.tf": readTerraformSource(t, "modules", "control_plane", "fleet", "job_diagnostics_resolver.tf"),
+		"control_plane/fleet/secrets.tf":                  readTerraformSource(t, "modules", "control_plane", "fleet", "secrets.tf"),
+		"control_plane/alerts/main.tf":                    readTerraformSource(t, "modules", "control_plane", "alerts", "main.tf"),
+	}
+
+	for name, source := range files {
+		assert.NotContains(t, source, "path.cwd", "%s should not make Lambda artifact filenames checkout-path dependent", name)
+		assert.Contains(t, source, "sha1(var.stack_name)", "%s should keep Lambda artifact filenames stable for a given stack", name)
+	}
+}
+
 func TestPlanSourceFleetCIStackKeepsPrivateSubnetsStable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Make generated Lambda archive filenames derive from `stack_name` instead of `path.cwd`, avoiding unrelated Lambda updates when planning from different working directories.

Closes: #52 