### PR TITLE
Drop workflow_job webhooks that carry no usable job object

### DIFF
--- a/lambdas/github_webhooks.js
+++ b/lambdas/github_webhooks.js
@@ -98,9 +98,21 @@ function webhookLogFields(payload, eventType, deliveryId) {
   return fields;
 }
 
+// GitHub intermittently delivers workflow_job events whose job object is an
+// explicit null, and an unparseable body leaves payload null here too. Either
+// way there is no job id and no labels, so nothing can be scheduled from the
+// event.
+function isUsableWorkflowJob(payload) {
+  const job = payload?.workflow_job;
+  return Boolean(job) && typeof job === 'object';
+}
+
 function shouldEnqueueWebhook(payload, eventType) {
   if (eventType !== 'workflow_job') return true;
-  const labels = Array.isArray(payload?.workflow_job?.labels) ? payload.workflow_job.labels : null;
+  // Drop unusable events at the door rather than forward something the
+  // consumer cannot act on.
+  if (!isUsableWorkflowJob(payload)) return false;
+  const labels = Array.isArray(payload.workflow_job.labels) ? payload.workflow_job.labels : null;
   if (!labels) return true;
   return labels.some((label) => {
     const value = String(label || '');
@@ -208,7 +220,14 @@ function createHandler(options = {}) {
       return jsonResponse(202, { status: 'ignored', reason: 'invalid_payload' });
     }
     if (!shouldEnqueueWebhook(parsedBody, eventType)) {
-      log('info', 'Skipping GitHub webhook without RunsOn labels', logFields);
+      const unusableJob = eventType === 'workflow_job' && !isUsableWorkflowJob(parsedBody);
+      log(
+        'info',
+        unusableJob
+          ? 'Skipping workflow_job webhook with no usable job object'
+          : 'Skipping GitHub webhook without RunsOn labels',
+        logFields,
+      );
       return jsonResponse(202, { status: 'ignored' });
     }
 


### PR DESCRIPTION
Fixes the ingress half of runs-on/runs-on#528, where `flexd` panics and restarts on `workflow_job` webhooks whose job object is `null`.

## Problem

GitHub intermittently delivers this shape:

```json
{"action": "queued", "workflow_job": null, "repository": {...}, "sender": {...}}
```

Valid JSON, key present, value explicitly null — roughly 0.07% of `workflow_job` events on our stack.

`shouldEnqueueWebhook` forwards it, because the label check falls back to *enqueue* whenever it cannot read labels, and a null job has none:

```js
const labels = Array.isArray(payload?.workflow_job?.labels) ? payload.workflow_job.labels : null;
if (!labels) return true;   // forwards the null-job event
```

The consumer then dereferences the nil `*WorkflowJob` at `pkg/flex/jobs/webhook.go:170` and the process dies on SIGSEGV. With no `recover()` on that consume path, the whole control plane goes down and ECS restarts it — 57 task restarts in 19.5 hours on a `desiredCount = 1` service.

Each panic also returns the in-flight `ReceiveMessage` batch with an incremented receive count, so with `maxReceiveCount: 3` the poison message takes up to nine healthy siblings to the DLQ with it. A 180-message DLQ sample was 13 null-job events and 167 well-formed ones.

## Change

Fail closed for `workflow_job` when there is no usable job object. This isn't masking the panic — such an event has **no job id and no labels**, so nothing can be scheduled from it and dropping it loses no work.

Unparseable bodies reach the same branch (`parsedBody` is `null` on a `JSON.parse` throw) and are now dropped for `workflow_job` too; they were never actionable either. **Other event types keep the existing pass-through behaviour.**

The skip log distinguishes the two reasons, so this is diagnosable without pulling a stack trace out of CloudWatch.

## Verification

Behavioural check against the exported handler with mocked AWS:

| case | enqueued | expected |
|---|---|---|
| `workflow_job` with `workflow_job: null` | 0 | 0 |
| `workflow_job` with valid runs-on labels | 1 | 1 |
| `workflow_job` with non-runs-on labels | 0 | 0 |
| `installation` event | 1 | 1 |

This repo has no test directory, so nothing is committed for it. The monorepo's `scripts/public_ingress_lambda.test.js` is where these belong — I have the three cases written against it (one changed assertion for the previously-tested fail-open behaviour, two new) and am happy to send them in whatever form suits.

## Needs your release tooling

Two artifacts carry a copy of this function and I cannot regenerate either from here:

- **`lambdas/dist/public-ingress.zip`** in this repo. `modules/control_plane/flex/ingress.tf` deploys the prebuilt zip via `filename` + `filebase64sha256`, not an `archive_file` built from source — so **this PR as it stands is a no-op on apply** until that artifact is rebuilt.
- **`cloudformation/template.yaml`** in `runs-on/runs-on`, which inlines the same function and per the monorepo's `AGENTS.md` should be regenerated with `scripts/sync-cloudformation-inline-lambdas.py` rather than hand-edited.

Happy to push a rebuilt zip here if you would rather have it in the PR.

## Note on the underlying defect

This narrows the input; it does not remove the crash. Any other unexpected shape reaching `HandleWorkflowJob` will still terminate the process. The durable fixes are described in runs-on/runs-on#528 — a nil guard at `webhook.go:170`, and a `recover()` on the webhook consume path (the pattern is already used in `maintenance/events.go`, `maintenance/housekeeping.go` and the githubapp cache, just not there).

Branched from `main` at the v3.2.2 sync; the bug is present on current `main`, so this isn't resolved by upgrading.
