### PR TITLE
fix(alerts): drop redundant nonsensitive on slack webhook arn output

### DIFF
--- a/modules/control_plane/alerts/outputs.tf
+++ b/modules/control_plane/alerts/outputs.tf
@@ -10,5 +10,5 @@ output "topic_name" {
 
 output "slack_webhook_lambda_arn" {
   description = "Slack webhook Lambda ARN when Slack alerting is enabled."
-  value       = nonsensitive(local.slack_webhook_enabled ? aws_lambda_function.slack_webhook[0].arn : null)
+  value       = local.slack_webhook_enabled ? aws_lambda_function.slack_webhook[0].arn : null
 }


### PR DESCRIPTION
This output wraps a value that `main.tf` already unwrapped a few lines earlier, so nothing sensitive ever reaches it. On Terraform older than 1.7 that redundant call is a hard error and it fires at output evaluation once every resource is already built.

- hit this on `modules/flex` v3.2.0 with Terraform 1.5.7 and Terragrunt, Slack alerting on, which failed the apply with `Invalid value for "value" parameter: the given value is not sensitive, so this call is redundant`
- drop the wrapper, the value carries no sensitive mark to remove
- see https://developer.hashicorp.com/terraform/language/functions/nonsensitive