### PR TITLE
feat(flex): allow opting into PITR for the transient locks table

### DIFF
--- a/modules/control_plane/flex/README.md
+++ b/modules/control_plane/flex/README.md
@@ -182,6 +182,7 @@ When `ebs_encryption_key_id` points at a customer-managed KMS key, prefer a full
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags for all resources | `map(string)` | n/a | yes |
 | <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings) | Non-sensitive stack settings exposed by the job diagnostics resolver | `any` | `{}` | no |
 | <a name="input_enable_cache_isolation"></a> [enable\_cache\_isolation](#input\_enable\_cache\_isolation) | Vend brokered, per-repository credentials for Magic Cache data under scoped-cache/*. The always-created broker stays idle when false; direct cache/* access is stack-shared in both modes | `bool` | `false` | no |
+| <a name="input_locks_table_point_in_time_recovery_enabled"></a> [locks\_table\_point\_in\_time\_recovery\_enabled](#input\_locks\_table\_point\_in\_time\_recovery\_enabled) | Enable DynamoDB point-in-time recovery for the transient locks table | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/control_plane/flex/dynamodb.tf
+++ b/modules/control_plane/flex/dynamodb.tf
@@ -20,6 +20,10 @@ resource "aws_dynamodb_table" "locks" {
     attribute_name = "expiresAt"
   }
 
+  point_in_time_recovery {
+    enabled = var.locks_table_point_in_time_recovery_enabled
+  }
+
   tags = merge(
     local.common_tags,
     {

--- a/modules/control_plane/flex/tests/plan_behavior.tofutest.hcl
+++ b/modules/control_plane/flex/tests/plan_behavior.tofutest.hcl
@@ -214,6 +214,28 @@ variables {
   tags = {}
 }
 
+run "locks_table_pitr_is_disabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = aws_dynamodb_table.locks.point_in_time_recovery[0].enabled == false
+    error_message = "The transient locks table should preserve its existing PITR-disabled default."
+  }
+}
+
+run "locks_table_pitr_can_be_enabled" {
+  command = plan
+
+  variables {
+    locks_table_point_in_time_recovery_enabled = true
+  }
+
+  assert {
+    condition     = aws_dynamodb_table.locks.point_in_time_recovery[0].enabled == true
+    error_message = "The transient locks table should enable PITR when explicitly requested."
+  }
+}
+
 run "zero_budget_skips_budget_resources" {
   command = plan
 

--- a/modules/control_plane/flex/variables.tf
+++ b/modules/control_plane/flex/variables.tf
@@ -212,6 +212,12 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "locks_table_point_in_time_recovery_enabled" {
+  description = "Enable DynamoDB point-in-time recovery for the transient locks table"
+  type        = bool
+  default     = false
+}
+
 variable "enable_cache_isolation" {
   description = "Vend brokered, per-repository credentials for Magic Cache data under scoped-cache/*. The always-created broker stays idle when false; direct cache/* access is stack-shared in both modes"
   type        = bool

--- a/modules/flex/README.md
+++ b/modules/flex/README.md
@@ -370,6 +370,7 @@ Minimal key-policy statement:
 | <a name="input_github_enterprise_url"></a> [github\_enterprise\_url](#input\_github\_enterprise\_url) | GitHub Enterprise Server URL (optional, leave empty for github.com) | `string` | `""` | no |
 | <a name="input_integration_step_security_api_key"></a> [integration\_step\_security\_api\_key](#input\_integration\_step\_security\_api\_key) | API key for StepSecurity integration (optional) | `string` | `""` | no |
 | <a name="input_ipv6_enabled"></a> [ipv6\_enabled](#input\_ipv6\_enabled) | Enable IPv6 support for runner instances | `bool` | `false` | no |
+| <a name="input_locks_table_point_in_time_recovery_enabled"></a> [locks\_table\_point\_in\_time\_recovery\_enabled](#input\_locks\_table\_point\_in\_time\_recovery\_enabled) | Enable DynamoDB point-in-time recovery for the transient locks table. This can help satisfy backup and compliance requirements, but incurs additional storage costs. | `bool` | `false` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to retain CloudWatch logs for EC2 instances | `number` | `7` | no |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | Logging level for RunsOn service (debug, info, warn, error) | `string` | `"info"` | no |
 | <a name="input_maintenance_mode"></a> [maintenance\_mode](#input\_maintenance\_mode) | Enable maintenance mode (disables queue processing and leader election) | `bool` | `false` | no |

--- a/modules/flex/main.tf
+++ b/modules/flex/main.tf
@@ -343,21 +343,22 @@ module "control_plane" {
   region     = local.region
   account_id = local.account_id
 
-  stack_name             = var.stack_name
-  environment            = var.environment
-  cost_allocation_tag    = var.cost_allocation_tag
-  license_key            = var.license_key
-  network                = module.network.network
-  extras                 = module.extras.extras
-  compute                = module.compute.compute
-  github                 = local.flex_github
-  runtime                = local.flex_runtime
-  runner                 = local.flex_runner
-  operations             = local.flex_operations
-  diagnostic_settings    = local.flex_diagnostic_settings
-  alerts                 = local.flex_alerts
-  enable_cache_isolation = var.enable_cache_isolation
-  tags                   = local.common_tags
+  stack_name                                 = var.stack_name
+  environment                                = var.environment
+  cost_allocation_tag                        = var.cost_allocation_tag
+  license_key                                = var.license_key
+  network                                    = module.network.network
+  extras                                     = module.extras.extras
+  compute                                    = module.compute.compute
+  github                                     = local.flex_github
+  runtime                                    = local.flex_runtime
+  runner                                     = local.flex_runner
+  operations                                 = local.flex_operations
+  diagnostic_settings                        = local.flex_diagnostic_settings
+  alerts                                     = local.flex_alerts
+  enable_cache_isolation                     = var.enable_cache_isolation
+  locks_table_point_in_time_recovery_enabled = var.locks_table_point_in_time_recovery_enabled
+  tags                                       = local.common_tags
 
   # Ensure NAT gateway is ready before the worker service starts
   depends_on = [

--- a/modules/flex/variables.tf
+++ b/modules/flex/variables.tf
@@ -162,6 +162,12 @@ variable "cache_bucket_versioning_enabled" {
   default     = false
 }
 
+variable "locks_table_point_in_time_recovery_enabled" {
+  description = "Enable DynamoDB point-in-time recovery for the transient locks table. This can help satisfy backup and compliance requirements, but incurs additional storage costs."
+  type        = bool
+  default     = false
+}
+
 variable "force_destroy_buckets" {
   description = "Allow S3 buckets to be destroyed even when not empty. Set to false for production environments to prevent accidental data loss."
   type        = bool


### PR DESCRIPTION
## Summary

- add `locks_table_point_in_time_recovery_enabled` to the public Flex module
- preserve the existing behavior with a `false` default
- wire the opt-in to the transient `locks` DynamoDB table
- add plan coverage for both the default and enabled configurations
- regenerate the affected module documentation

## Motivation

Some organizations require point-in-time recovery on every active DynamoDB table for backup and compliance controls. I saw the decision on #41 to keep PITR disabled for the transient `locks` table, so this PR does not change that default and does not add a switch for tables that already have PITR permanently enabled. It only lets callers explicitly opt in when their policy requires it.

## Validation

- `make test-plan-tofu` — all OpenTofu module tests passed
- `tofu test -filter=tests/plan_behavior.tofutest.hcl` in `modules/control_plane/flex` — 20 passed
- `tofu test -filter=tests/root.tftest.hcl` in `modules/flex` — 26 passed
- `tofu fmt -check -recursive`

`make test-plan-source` cannot run completely from this exported repository because several `TestPlanSource*` cases reference monorepo-only paths that are not published here (`cloudformation/`, `stacks/`, `.github/workflows/`, and agent source). The structured Terraform plan tests and resource-count tests completed successfully.
